### PR TITLE
Visually distinguish log divider from commit-graph line.

### DIFF
--- a/src/main/kotlin/com/jetpackduba/gitnuro/ui/log/Log.kt
+++ b/src/main/kotlin/com/jetpackduba/gitnuro/ui/log/Log.kt
@@ -1041,8 +1041,8 @@ fun DividerLog(modifier: Modifier, graphWidth: Dp) {
         Box(
             modifier = Modifier
                 .fillMaxHeight()
-                .width(1.dp)
-                .background(color = MaterialTheme.colors.primaryVariant)
+                .width(3.dp)
+                .background(color = MaterialTheme.colors.surface)
                 .align(Alignment.Center)
         )
     }


### PR DESCRIPTION
The divider between the logs' commit graph and messages sections used the the primary accent color, which is bright and powerful, just like the commit-graph lines right next to it.

The only reliable way to see they're different is the way the divider line extends up into the header bar.
However, that is quite some eye-moving distance away from most of the view area.

To create visual difference between the commit graph and the dragable divider, make the divider less noticeable by coloring it in the "surface" color.
Also make it wider, so it becomes more like the padding elsewhere. This makes it clearer that it's a UI thing, not a graph thing.

Screenshots of before and after:

Before: Which is the divider, which is commit graph?
![Gitnuro-which-is-divider](https://github.com/user-attachments/assets/352e9cf4-df2f-4e2b-b864-4799b5766d38)

After: surface-coloured, wide line is more clearly a UI element, not a branch-line:
![Gitnuro-divider-distinct-shape](https://github.com/user-attachments/assets/f6e50527-4677-4990-9a6c-b488e7e9c768)
