### PR TITLE
Add open-in-editor action

### DIFF
--- a/src/main/composeResources/values/strings.xml
+++ b/src/main/composeResources/values/strings.xml
@@ -37,6 +37,8 @@
     <string name="menu_pop_stash_tooltip">Pop the last stash</string>
     <string name="menu_terminal">Terminal</string>
     <string name="menu_terminal_tooltip">Open a terminal in the repository's path</string>
+    <string name="menu_editor">Editor</string>
+    <string name="menu_editor_tooltip">Open a repository in external editor</string>
     <string name="menu_actions">Actions</string>
     <string name="menu_actions_tooltip">Additional actions</string>
     <string name="menu_settings">Settings</string>

--- a/src/main/kotlin/com/jetpackduba/gitnuro/editor/OpenRepositoryInEditorUseCase.kt
+++ b/src/main/kotlin/com/jetpackduba/gitnuro/editor/OpenRepositoryInEditorUseCase.kt
@@ -1,0 +1,34 @@
+package com.jetpackduba.gitnuro.editor
+
+import com.jetpackduba.gitnuro.managers.ErrorsManager
+import com.jetpackduba.gitnuro.managers.IShellManager
+import com.jetpackduba.gitnuro.models.errorNotification
+import com.jetpackduba.gitnuro.repositories.AppSettingsRepository
+import javax.inject.Inject
+
+/**
+ * Use-case for opening the repository directory with an external editor.
+ */
+class OpenRepositoryInEditorUseCase @Inject constructor(
+    private val settings: AppSettingsRepository,
+    private val shellManager: IShellManager,
+    private val errorsManager: ErrorsManager
+) {
+    /**
+     * Opens the given path in the configured external editor.
+     * @param path The path to open. Should be a directory.
+     */
+    suspend operator fun invoke(path: String) {
+        val editor = settings.editor;
+        val isSet = editor.isNotEmpty();
+
+        if (!isSet) {
+            errorsManager.emitNotification(
+                errorNotification("No editor configured")
+            )
+            return
+        }
+
+        shellManager.runCommandInPath(listOf(editor, path), path)
+    }
+}

--- a/src/main/kotlin/com/jetpackduba/gitnuro/keybindings/Keybinding.kt
+++ b/src/main/kotlin/com/jetpackduba/gitnuro/keybindings/Keybinding.kt
@@ -97,6 +97,11 @@ enum class KeybindingOption {
      * Used to open the settings screen
      */
     SETTINGS,
+
+    /**
+     * Used to open the current repository in an external editor
+     */
+    OPEN_EDITOR
 }
 
 
@@ -156,6 +161,9 @@ private fun baseKeybindings() = mapOf(
     KeybindingOption.SETTINGS to listOf(
         Keybinding(key = Key.S, control = true, alt = true),
     ),
+    KeybindingOption.OPEN_EDITOR to listOf(
+        Keybinding(key = Key.A, control = true, shift = true),
+    ),
 )
 
 private fun linuxKeybindings(): Map<KeybindingOption, List<Keybinding>> = baseKeybindings()
@@ -179,6 +187,7 @@ private fun macKeybindings(): Map<KeybindingOption, List<Keybinding>> {
             KeybindingOption.CHANGE_CURRENT_TAB_RIGHT,
             KeybindingOption.CHANGE_CURRENT_TAB_LEFT,
             KeybindingOption.SETTINGS,
+            KeybindingOption.OPEN_EDITOR,
         )
 
         for (key in keysToReplaceControlWithCommand) {

--- a/src/main/kotlin/com/jetpackduba/gitnuro/repositories/AppSettingsRepository.kt
+++ b/src/main/kotlin/com/jetpackduba/gitnuro/repositories/AppSettingsRepository.kt
@@ -61,6 +61,8 @@ private const val PREF_GIT_PUSH_WITH_LEASE = "gitPushWithLease"
 
 private const val PREF_VERIFY_SSL = "verifySsl"
 
+private const val PREF_EDITOR = "editor"
+
 private const val DEFAULT_SWAP_UNCOMMITTED_CHANGES = false
 private const val DEFAULT_SHOW_CHANGES_AS_TREE = false
 private const val DEFAULT_CACHE_CREDENTIALS_IN_MEMORY = true
@@ -90,6 +92,9 @@ class AppSettingsRepository @Inject constructor() {
 
     private val _verifySslFlow = MutableStateFlow(cacheCredentialsInMemory)
     val verifySslFlow = _verifySslFlow.asStateFlow()
+
+    private val _editorFlow = MutableStateFlow(editor)
+    val editorFlow = _editorFlow.asStateFlow()
 
     private val _defaultCloneDirFlow = MutableStateFlow(defaultCloneDir)
     val defaultCloneDirFlow = _defaultCloneDirFlow.asStateFlow()
@@ -239,6 +244,15 @@ class AppSettingsRepository @Inject constructor() {
         set(value) {
             preferences.putBoolean(PREF_VERIFY_SSL, value)
             _verifySslFlow.value = value
+        }
+
+    var editor: String
+        get() {
+            return preferences.get(PREF_EDITOR, "")
+        }
+        set(value) {
+            preferences.put(PREF_EDITOR, value)
+            _editorFlow.value = value
         }
 
     var scaleUi: Float

--- a/src/main/kotlin/com/jetpackduba/gitnuro/repositories/AppSettingsRepository.kt
+++ b/src/main/kotlin/com/jetpackduba/gitnuro/repositories/AppSettingsRepository.kt
@@ -255,6 +255,9 @@ class AppSettingsRepository @Inject constructor() {
             _editorFlow.value = value
         }
 
+    val hasEditorSet: Boolean
+        get() = editor.isNotEmpty()
+
     var scaleUi: Float
         get() {
             return preferences.getFloat(PREF_UI_SCALE, DEFAULT_UI_SCALE)

--- a/src/main/kotlin/com/jetpackduba/gitnuro/repositories/AppSettingsRepository.kt
+++ b/src/main/kotlin/com/jetpackduba/gitnuro/repositories/AppSettingsRepository.kt
@@ -255,9 +255,6 @@ class AppSettingsRepository @Inject constructor() {
             _editorFlow.value = value
         }
 
-    val hasEditorSet: Boolean
-        get() = editor.isNotEmpty()
-
     var scaleUi: Float
         get() {
             return preferences.getFloat(PREF_UI_SCALE, DEFAULT_UI_SCALE)

--- a/src/main/kotlin/com/jetpackduba/gitnuro/ui/Menu.kt
+++ b/src/main/kotlin/com/jetpackduba/gitnuro/ui/Menu.kt
@@ -176,6 +176,15 @@ fun Menu(
 
         MenuButton(
             modifier = Modifier.padding(end = 4.dp),
+            title = stringResource(Res.string.menu_editor),
+            icon = painterResource(Res.drawable.edit),
+            onClick = { menuViewModel.openEditor() },
+            tooltip = stringResource(Res.string.menu_editor_tooltip),
+            keybinding = KeybindingOption.OPEN_EDITOR.keyBinding,
+        )
+
+        MenuButton(
+            modifier = Modifier.padding(end = 4.dp),
             title = stringResource(Res.string.menu_actions),
             icon = painterResource(Res.drawable.bolt),
             onClick = onQuickActions,

--- a/src/main/kotlin/com/jetpackduba/gitnuro/ui/RepositoryOpen.kt
+++ b/src/main/kotlin/com/jetpackduba/gitnuro/ui/RepositoryOpen.kt
@@ -166,6 +166,11 @@ fun RepositoryOpenPage(
                         true
                     }
 
+                    it.matchesBinding(KeybindingOption.OPEN_EDITOR) -> {
+                        repositoryOpenViewModel.openFolderInEditor()
+                        true
+                    }
+
                     else -> false
                 }
 

--- a/src/main/kotlin/com/jetpackduba/gitnuro/ui/RepositoryOpen.kt
+++ b/src/main/kotlin/com/jetpackduba/gitnuro/ui/RepositoryOpen.kt
@@ -94,6 +94,7 @@ fun RepositoryOpenPage(
                 showQuickActionsDialog = false
                 when (it) {
                     QuickActionType.OPEN_DIR_IN_FILE_MANAGER -> repositoryOpenViewModel.openFolderInFileExplorer()
+                    QuickActionType.OPEN_DIR_IN_EDITOR -> repositoryOpenViewModel.openFolderInEditor()
                     QuickActionType.CLONE -> onShowCloneDialog()
                     QuickActionType.REFRESH -> repositoryOpenViewModel.refreshAll()
                     QuickActionType.SIGN_OFF -> showSignOffDialog = true

--- a/src/main/kotlin/com/jetpackduba/gitnuro/ui/dialogs/QuickActionsDialog.kt
+++ b/src/main/kotlin/com/jetpackduba/gitnuro/ui/dialogs/QuickActionsDialog.kt
@@ -36,6 +36,7 @@ fun QuickActionsDialog(
     val items = remember {
         listOf(
             QuickAction(Res.drawable.code, "Open repository in file manager", QuickActionType.OPEN_DIR_IN_FILE_MANAGER),
+            QuickAction(Res.drawable.code, "Open repository in editor", QuickActionType.OPEN_DIR_IN_EDITOR),
             QuickAction(Res.drawable.download, "Clone new repository", QuickActionType.CLONE),
             QuickAction(Res.drawable.refresh, "Refresh repository data", QuickActionType.REFRESH),
             QuickAction(Res.drawable.sign, "Signoff config", QuickActionType.SIGN_OFF),
@@ -128,6 +129,7 @@ data class QuickAction(val icon: DrawableResource, val title: String, val type: 
 
 enum class QuickActionType {
     OPEN_DIR_IN_FILE_MANAGER,
+    OPEN_DIR_IN_EDITOR,
     CLONE,
     REFRESH,
     SIGN_OFF

--- a/src/main/kotlin/com/jetpackduba/gitnuro/ui/dialogs/settings/SettingsDialog.kt
+++ b/src/main/kotlin/com/jetpackduba/gitnuro/ui/dialogs/settings/SettingsDialog.kt
@@ -73,6 +73,7 @@ val settings = listOf(
 
     SettingsEntry.Section("Tools"),
     SettingsEntry.Entry(Res.drawable.terminal, "Terminal") { Terminal(it) },
+    SettingsEntry.Entry(Res.drawable.edit, "Editor") { Editor(it) },
     SettingsEntry.Entry(Res.drawable.info, "Logs") { Logs(it) },
 )
 
@@ -354,6 +355,20 @@ private fun Security(settingsViewModel: SettingsViewModel) {
         onValueChanged = { value ->
             settingsViewModel.verifySsl = !value
         }
+    )
+}
+
+@Composable
+fun Editor(settingsViewModel: SettingsViewModel) {
+    val editor by settingsViewModel.editorFlow.collectAsState()
+
+    SettingTextInput(
+        title = "External editor path",
+        subtitle = "Configure an external editor to open the repository with",
+        value = editor,
+        onValueChanged = { value ->
+            settingsViewModel.editor = value
+        },
     )
 }
 

--- a/src/main/kotlin/com/jetpackduba/gitnuro/viewmodels/GlobalMenuActionsViewModel.kt
+++ b/src/main/kotlin/com/jetpackduba/gitnuro/viewmodels/GlobalMenuActionsViewModel.kt
@@ -1,6 +1,7 @@
 package com.jetpackduba.gitnuro.viewmodels
 
 import com.jetpackduba.gitnuro.TaskType
+import com.jetpackduba.gitnuro.editor.OpenRepositoryInEditorUseCase
 import com.jetpackduba.gitnuro.git.RefreshType
 import com.jetpackduba.gitnuro.git.TabState
 import com.jetpackduba.gitnuro.git.remote_operations.FetchAllRemotesUseCase
@@ -23,6 +24,7 @@ interface IGlobalMenuActionsViewModel {
     fun stash(): Job
     fun popStash(): Job
     fun openTerminal(): Job
+    fun openEditor(): Job
 }
 
 class GlobalMenuActionsViewModel @Inject constructor(
@@ -33,6 +35,7 @@ class GlobalMenuActionsViewModel @Inject constructor(
     private val popLastStashUseCase: PopLastStashUseCase,
     private val stashChangesUseCase: StashChangesUseCase,
     private val openRepositoryInTerminalUseCase: OpenRepositoryInTerminalUseCase,
+    private val openRepositoryInEditorUseCase: OpenRepositoryInEditorUseCase,
 ) : IGlobalMenuActionsViewModel {
     override fun pull(pullType: PullType) = tabState.safeProcessing(
         refreshType = RefreshType.ALL_DATA,
@@ -99,5 +102,11 @@ class GlobalMenuActionsViewModel @Inject constructor(
         refreshType = RefreshType.NONE
     ) { git ->
         openRepositoryInTerminalUseCase(git.repository.workTree.absolutePath)
+    }
+
+    override fun openEditor() = tabState.runOperation(
+        refreshType = RefreshType.NONE
+    ) { git ->
+        openRepositoryInEditorUseCase(git.repository.workTree.absolutePath)
     }
 }

--- a/src/main/kotlin/com/jetpackduba/gitnuro/viewmodels/RepositoryOpenViewModel.kt
+++ b/src/main/kotlin/com/jetpackduba/gitnuro/viewmodels/RepositoryOpenViewModel.kt
@@ -358,10 +358,7 @@ class RepositoryOpenViewModel @Inject constructor(
         showError = true,
         refreshType = RefreshType.NONE,
     ) { git ->
-        val editor = appSettings.editor;
-
-        // TODO: Verify editor input when saving instead of here when using it
-        if (editor.trim().isEmpty()) {
+        if (!appSettings.hasEditorSet) {
             errorsManager.emitNotification(
                 errorNotification("No editor configured")
             )
@@ -369,7 +366,7 @@ class RepositoryOpenViewModel @Inject constructor(
         }
 
         val dir = git.repository.workTree;
-        val processBuilder = ProcessBuilder(editor, dir.path)
+        val processBuilder = ProcessBuilder(appSettings.editor, dir.path)
         processBuilder.directory(dir)
         processBuilder.start()
     }

--- a/src/main/kotlin/com/jetpackduba/gitnuro/viewmodels/RepositoryOpenViewModel.kt
+++ b/src/main/kotlin/com/jetpackduba/gitnuro/viewmodels/RepositoryOpenViewModel.kt
@@ -2,6 +2,7 @@ package com.jetpackduba.gitnuro.viewmodels
 
 import com.jetpackduba.gitnuro.SharedRepositoryStateManager
 import com.jetpackduba.gitnuro.TaskType
+import com.jetpackduba.gitnuro.editor.OpenRepositoryInEditorUseCase
 import com.jetpackduba.gitnuro.exceptions.codeToMessage
 import com.jetpackduba.gitnuro.git.*
 import com.jetpackduba.gitnuro.git.branches.CreateBranchUseCase
@@ -64,14 +65,13 @@ class RepositoryOpenViewModel @Inject constructor(
     private val stashChangesUseCase: StashChangesUseCase,
     private val stageUntrackedFileUseCase: StageUntrackedFileUseCase,
     private val openFilePickerUseCase: OpenFilePickerUseCase,
+    private val openInEditorUseCase: OpenRepositoryInEditorUseCase,
     private val openUrlInBrowserUseCase: OpenUrlInBrowserUseCase,
     private val tabsManager: TabsManager,
     private val tabScope: CoroutineScope,
     private val verticalSplitPaneConfig: VerticalSplitPaneConfig,
     val tabViewModelsProvider: ViewModelsProvider,
     private val globalMenuActionsViewModel: GlobalMenuActionsViewModel,
-    private val appSettings: AppSettingsRepository,
-    private val shellManager: IShellManager,
     sharedRepositoryStateManager: SharedRepositoryStateManager,
     updatesRepository: UpdatesRepository,
 ) : IVerticalSplitPaneConfig by verticalSplitPaneConfig,
@@ -360,15 +360,7 @@ class RepositoryOpenViewModel @Inject constructor(
         showError = true,
         refreshType = RefreshType.NONE,
     ) { git ->
-        if (!appSettings.hasEditorSet) {
-            errorsManager.emitNotification(
-                errorNotification("No editor configured")
-            )
-            return@runOperation
-        }
-
-        val dir = git.repository.workTree;
-        shellManager.runCommandInPath(listOf(appSettings.editor, dir.path), dir.path)
+      openInEditorUseCase(git.repository.workTree.path)
     }
 
     fun openUrlInBrowser(url: String) {

--- a/src/main/kotlin/com/jetpackduba/gitnuro/viewmodels/RepositoryOpenViewModel.kt
+++ b/src/main/kotlin/com/jetpackduba/gitnuro/viewmodels/RepositoryOpenViewModel.kt
@@ -361,8 +361,12 @@ class RepositoryOpenViewModel @Inject constructor(
         val editor = appSettings.editor;
 
         // TODO: Verify editor input when saving instead of here when using it
-        // TODO: Show some message to the user
-        if(editor.trim().isEmpty()) return@runOperation
+        if (editor.trim().isEmpty()) {
+            errorsManager.emitNotification(
+                errorNotification("No editor configured")
+            )
+            return@runOperation
+        }
 
         val dir = git.repository.workTree;
         val processBuilder = ProcessBuilder(editor, dir.path)

--- a/src/main/kotlin/com/jetpackduba/gitnuro/viewmodels/RepositoryOpenViewModel.kt
+++ b/src/main/kotlin/com/jetpackduba/gitnuro/viewmodels/RepositoryOpenViewModel.kt
@@ -352,6 +352,17 @@ class RepositoryOpenViewModel @Inject constructor(
         Desktop.getDesktop().open(git.repository.workTree)
     }
 
+    fun openFolderInEditor() = tabState.runOperation(
+        showError = true,
+        refreshType = RefreshType.NONE,
+    ) { git ->
+        val dir = git.repository.workTree;
+        // TODO: Make editor configurable
+        val processBuilder = ProcessBuilder("vscodium", dir.path)
+        processBuilder.directory(dir)
+        processBuilder.start()
+    }
+
     fun openUrlInBrowser(url: String) {
         openUrlInBrowserUseCase(url)
     }

--- a/src/main/kotlin/com/jetpackduba/gitnuro/viewmodels/RepositoryOpenViewModel.kt
+++ b/src/main/kotlin/com/jetpackduba/gitnuro/viewmodels/RepositoryOpenViewModel.kt
@@ -16,6 +16,7 @@ import com.jetpackduba.gitnuro.managers.newErrorNow
 import com.jetpackduba.gitnuro.models.AuthorInfoSimple
 import com.jetpackduba.gitnuro.models.errorNotification
 import com.jetpackduba.gitnuro.models.positiveNotification
+import com.jetpackduba.gitnuro.repositories.AppSettingsRepository
 import com.jetpackduba.gitnuro.system.OpenFilePickerUseCase
 import com.jetpackduba.gitnuro.system.OpenUrlInBrowserUseCase
 import com.jetpackduba.gitnuro.system.PickerType
@@ -68,6 +69,7 @@ class RepositoryOpenViewModel @Inject constructor(
     private val verticalSplitPaneConfig: VerticalSplitPaneConfig,
     val tabViewModelsProvider: ViewModelsProvider,
     private val globalMenuActionsViewModel: GlobalMenuActionsViewModel,
+    private val appSettings: AppSettingsRepository,
     sharedRepositoryStateManager: SharedRepositoryStateManager,
     updatesRepository: UpdatesRepository,
 ) : IVerticalSplitPaneConfig by verticalSplitPaneConfig,
@@ -356,9 +358,14 @@ class RepositoryOpenViewModel @Inject constructor(
         showError = true,
         refreshType = RefreshType.NONE,
     ) { git ->
+        val editor = appSettings.editor;
+
+        // TODO: Verify editor input when saving instead of here when using it
+        // TODO: Show some message to the user
+        if(editor.trim().isEmpty()) return@runOperation
+
         val dir = git.repository.workTree;
-        // TODO: Make editor configurable
-        val processBuilder = ProcessBuilder("vscodium", dir.path)
+        val processBuilder = ProcessBuilder(editor, dir.path)
         processBuilder.directory(dir)
         processBuilder.start()
     }

--- a/src/main/kotlin/com/jetpackduba/gitnuro/viewmodels/RepositoryOpenViewModel.kt
+++ b/src/main/kotlin/com/jetpackduba/gitnuro/viewmodels/RepositoryOpenViewModel.kt
@@ -12,6 +12,7 @@ import com.jetpackduba.gitnuro.logging.printDebug
 import com.jetpackduba.gitnuro.logging.printLog
 import com.jetpackduba.gitnuro.managers.AppStateManager
 import com.jetpackduba.gitnuro.managers.ErrorsManager
+import com.jetpackduba.gitnuro.managers.IShellManager
 import com.jetpackduba.gitnuro.managers.newErrorNow
 import com.jetpackduba.gitnuro.models.AuthorInfoSimple
 import com.jetpackduba.gitnuro.models.errorNotification
@@ -70,6 +71,7 @@ class RepositoryOpenViewModel @Inject constructor(
     val tabViewModelsProvider: ViewModelsProvider,
     private val globalMenuActionsViewModel: GlobalMenuActionsViewModel,
     private val appSettings: AppSettingsRepository,
+    private val shellManager: IShellManager,
     sharedRepositoryStateManager: SharedRepositoryStateManager,
     updatesRepository: UpdatesRepository,
 ) : IVerticalSplitPaneConfig by verticalSplitPaneConfig,
@@ -366,9 +368,7 @@ class RepositoryOpenViewModel @Inject constructor(
         }
 
         val dir = git.repository.workTree;
-        val processBuilder = ProcessBuilder(appSettings.editor, dir.path)
-        processBuilder.directory(dir)
-        processBuilder.start()
+        shellManager.runCommandInPath(listOf(appSettings.editor, dir.path), dir.path)
     }
 
     fun openUrlInBrowser(url: String) {

--- a/src/main/kotlin/com/jetpackduba/gitnuro/viewmodels/SettingsViewModel.kt
+++ b/src/main/kotlin/com/jetpackduba/gitnuro/viewmodels/SettingsViewModel.kt
@@ -43,6 +43,7 @@ class SettingsViewModel @Inject constructor(
     val swapUncommittedChangesFlow = appSettingsRepository.swapUncommittedChangesFlow
     val cacheCredentialsInMemoryFlow = appSettingsRepository.cacheCredentialsInMemoryFlow
     val verifySslFlow = appSettingsRepository.verifySslFlow
+    val editorFlow = appSettingsRepository.editorFlow
     val terminalPathFlow = appSettingsRepository.terminalPathFlow
     val avatarProviderFlow = appSettingsRepository.avatarProviderTypeFlow
     val dateFormatFlow = appSettingsRepository.dateTimeFormatFlow
@@ -88,6 +89,12 @@ class SettingsViewModel @Inject constructor(
         get() = appSettingsRepository.verifySsl
         set(value) {
             appSettingsRepository.verifySsl = value
+        }
+
+    var editor: String
+        get() = appSettingsRepository.editor
+        set(value) {
+            appSettingsRepository.editor = value
         }
 
     var pullRebase: Boolean


### PR DESCRIPTION
This PR implements functionality to open the current repository in an external editor. Below are the main changes:

1. Added setting for configuring external editor path
2. Add quick action for opening repo with editor
3. Add global menu action for opening repo with editor
4. Add CTRL+SHIFT+A shortcut for opening the repo

![Screencast_20251013_151754](https://github.com/user-attachments/assets/97b5110e-b3dc-4efd-8b39-af16cba76102)

Things that could still be added:

- Validate that the entered path is actually a code editor
- Better error handling if no valid editor was specified. Currently, when I enter some random string like `not an editor` into the editor, it will still be saved and only fails once it tries to actually run that command. We then get an ugly error notification with some low-level error details. Would be nice to hide those
- Per-project overrides for the editor setting

A few notes:

- This is my first time contributing to this repo, so I was not sure what the best place to put things was. Please let me know if there are any corrections
- I broke the changes into a few small commits, which can be squashed if that is preferred

This PR partially resolves #230 