### PR TITLE
Enable foojay resolver for automatic JDK provisioning

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,4 +6,7 @@ pluginManagement {
     }
 
 }
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention").version("1.0.0")
+}
 rootProject.name = "Gitnuro"


### PR DESCRIPTION
This PR allows Gradle to automatically download the appropriate JDK so that it doesn't have to be manually installed and configured.