### PR TITLE
feat: Support UI language selection

### DIFF
--- a/app/src/main/composeResources/values-ru/strings.xml
+++ b/app/src/main/composeResources/values-ru/strings.xml
@@ -1,0 +1,260 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Gitnuro</string>
+
+    <!-- Generic -->
+    <string name="generic_button_ok">OK</string>
+    <string name="generic_button_cancel">Отмена</string>
+    <string name="generic_button_continue">Продолжить</string>
+    <string name="generic_save_as_default">Сохранить по умолчанию</string>
+
+    <!-- Home page -->
+    <string name="home_button_open_repository">Открыть репозиторий</string>
+    <string name="home_button_clone_repository">Клонировать репозиторий</string>
+    <string name="home_button_start_repository">Создать локальный репозиторий</string>
+    <string name="home_label_additional_options">Дополнительные опции</string>
+    <string name="home_button_source_code">Исходный код</string>
+    <string name="home_button_report_bug">Сообщить об ошибке</string>
+    <string name="home_button_additional_information">Дополнительная информация</string>
+    <string name="home_button_settings">Настройки</string>
+    <string name="home_recent_repositories_search_label">Поиск в недавних репозиториях</string>
+    <string name="home_recent_repositories_list_empty">Пока пусто — сначала откройте репозиторий!</string>
+    <string name="home_recent_repositories_remove_repository">Убрать из недавних</string>
+
+    <!-- Top menu -->
+    <string name="menu_open">Открыть</string>
+    <string name="menu_open_dialog_title">Открыть репозиторий</string>
+    <string name="menu_open_tooltip">Открыть другой репозиторий</string>
+    <string name="menu_pull">Pull</string>
+    <string name="menu_pull_default">Pull текущей ветки</string>
+    <string name="menu_pull_rebase">Pull текущей ветки с rebase</string>
+    <string name="menu_pull_tooltip_disabled">Pull недоступен без удалённого репозитория</string>
+    <string name="menu_push">Push</string>
+    <string name="menu_push_tooltip">Отправить изменения текущей ветки</string>
+    <string name="menu_push_tooltip_disabled">Push недоступен без удалённого репозитория</string>
+    <string name="menu_branch">Ветка</string>
+    <string name="menu_branch_tooltip">Создать новую ветку</string>
+    <string name="menu_stash">Stash</string>
+    <string name="menu_stash_tooltip">Сохранить незакоммиченные изменения в stash</string>
+    <string name="menu_stash_tooltip_disabled">Измените файлы, чтобы сделать stash</string>
+    <string name="menu_pop_stash">Pop stash</string>
+    <string name="menu_pop_stash_tooltip">Применить последний stash</string>
+    <string name="menu_pop_stash_tooltip_disabled">Нет stash для применения</string>
+    <string name="menu_terminal">Терминал</string>
+    <string name="menu_terminal_tooltip">Открыть терминал в каталоге репозитория</string>
+    <string name="menu_actions">Действия</string>
+    <string name="menu_actions_tooltip">Дополнительные действия</string>
+    <string name="menu_settings">Настройки</string>
+    <string name="menu_settings_tooltip">Настройки Gitnuro</string>
+    <string name="rebase_interactive_view_title">Интерактивный rebase</string>
+    <string name="rebase_interactive_view_button_complete_rebase">Завершить rebase</string>
+
+    <!-- Bottom info bar -->
+    <string name="bottom_info_bar_name_and_email">%1$s &lt;%2$s&gt;</string>
+    <string name="bottom_info_bar_name_not_set">Имя не задано</string>
+    <string name="bottom_info_bar_email_not_set">Email не задан</string>
+    <string name="bottom_info_bar_update_available">Доступно обновление %1$s</string>
+    <string name="bottom_info_bar_app_version">Версия %1$s</string>
+
+    <!-- Side pane view -->
+    <string name="side_pane_search_hint">Поиск веток, тегов и др.</string>
+    <string name="side_pane_local_branches_title">Локальные ветки</string>
+    <string name="side_pane_local_branches_current_branch_label">HEAD</string>
+    <string name="side_pane_remotes_title">Remotes</string>
+    <string name="side_pane_tags_title">Теги</string>
+    <string name="side_pane_stashes_title">Stashes</string>
+    <string name="side_pane_submodules_title">Подмодули</string>
+
+    <!-- Uncommited changes view -->
+    <string name="uncommited_changes_unstaged_title">Unstaged</string>
+    <string name="uncommited_changes_unstaged_all_items_action">Stage все</string>
+    <string name="uncommited_changes_unstaged_selected_items_action">Stage выбранные</string>
+    <string name="uncommited_changes_unstaged_item_action">Stage</string>
+    <string name="uncommited_changes_staged_title">Staged</string>
+    <string name="uncommited_changes_staged_all_items_action">Unstage все</string>
+    <string name="uncommited_changes_staged_selected_items_action">Unstage выбранные</string>
+    <string name="uncommited_changes_staged_item_action">Unstage</string>
+    <string name="uncommited_changes_text_input_label_message_read_only">Сообщение коммита (только чтение)</string>
+    <string name="uncommited_changes_text_input_label_message">Введите сообщение коммита</string>
+    <string name="uncommited_changes_primary_button_commit">Commit</string>
+    <string name="uncommited_changes_primary_button_amend">Amend</string>
+    <string name="uncommited_changes_primary_button_merge">Merge</string>
+    <string name="uncommited_changes_primary_button_continue">Продолжить</string>
+    <string name="uncommited_changes_primary_button_skip">Пропустить</string>
+    <string name="uncommited_changes_secondary_button_abort">Отменить</string>
+    <string name="uncommited_changes_amend_check">Amend предыдущего коммита</string>
+
+    <!-- Merge automatic stash -->
+    <string name="merge_automatic_stash_description">Автоматический stash перед merge «%1$s» в «%2$s»</string>
+    <string name="pull_with_merge_automatic_stash_description">Автоматический stash перед pull «%1$s»</string>
+    <string name="pull_with_merge_from_specific_branch_automatic_stash_description">Автоматический stash перед pull из «%1$s» в «%2$s»</string>
+
+    <!-- Status entries context menu -->
+    <string name="status_entries_context_menu_delete_file">Удалить файл</string>
+    <string name="status_entries_context_menu_file_history">История файла</string>
+    <string name="status_entries_context_menu_blame_file">Blame файла</string>
+    <string name="status_entries_context_menu_discard_file_changes">Отменить изменения файла</string>
+    <string name="status_entries_context_menu_open_file_in_folder">Открыть файл в папке</string>
+    <string name="status_entries_context_menu_copy_file_absolute_path">Копировать путь</string>
+    <string name="status_entries_context_menu_copy_file_relative_path">Копировать относительный путь</string>
+    <string name="status_entries_context_menu_discard_multiple_files">Отменить изменения в %1$s файлах</string>
+    <string name="status_entries_context_menu_stage_multiple_files">Stage %1$s файлов</string>
+    <string name="status_entries_context_menu_unstage_multiple_files">Unstage %1$s файлов</string>
+    <string name="status_entries_context_menu_copy_files_absolute_paths">Копировать пути</string>
+    <string name="status_entries_context_menu_copy_files_relative_paths">Копировать относительные пути</string>
+
+    <!-- Branch context menu -->
+    <string name="branch_context_menu_checkout_branch">Переключиться на ветку</string>
+    <string name="branch_context_menu_merge_branch">Слить ветку</string>
+    <string name="branch_context_menu_rebase_branch">Rebase ветки</string>
+    <string name="branch_context_menu_push_current_to_target">Push «%1$s» в «%2$s»</string>
+    <string name="branch_context_menu_pull_target_to_current">Pull «%1$s» в «%2$s»</string>
+    <string name="branch_context_menu_rename_branch">Переименовать ветку</string>
+    <string name="branch_context_menu_change_default_upstream_branch">Изменить upstream по умолчанию</string>
+    <string name="branch_context_menu_delete_remote_branch">Удалить удалённую ветку</string>
+    <string name="branch_context_menu_delete_branch">Удалить ветку</string>
+    <string name="branch_context_menu_copy_branch_name">Копировать имя ветки</string>
+
+    <!-- Committed changes context menu -->
+    <string name="committed_changes_context_menu_blame_file">Blame файла</string>
+    <string name="committed_changes_context_menu_file_history">История файла</string>
+    <string name="committed_changes_context_menu_open_file_in_folder">Открыть файл в папке</string>
+
+    <!-- Log context menu -->
+    <string name="log_context_menu_checkout_commit">Checkout коммита</string>
+    <string name="log_context_menu_create_branch">Создать ветку</string>
+    <string name="log_context_menu_create_tag">Создать тег</string>
+    <string name="log_context_menu_rebase_interactive">Интерактивный rebase</string>
+    <string name="log_context_menu_revert_commit">Revert коммита</string>
+    <string name="log_context_menu_cherry_pick_commit">Cherry-pick коммита</string>
+    <string name="log_context_menu_reset_current_branch_to_commit">Сбросить текущую ветку на этот коммит</string>
+
+    <!-- Pull context menu -->
+    <string name="pull_context_menu_pull_with_merge">Pull с merge</string>
+    <string name="pull_context_menu_pull_with_rebase">Pull с rebase</string>
+    <string name="pull_context_menu_fetch_all">Fetch всех</string>
+
+    <!-- Push context menu -->
+    <string name="push_context_menu_push_including_tags">Push включая теги</string>
+    <string name="push_context_menu_force_push">Force push</string>
+
+    <!-- Remote context menu -->
+    <string name="remote_context_menu_edit">Изменить</string>
+    <string name="remote_context_menu_delete">Удалить</string>
+    <string name="remote_context_menu_fetch_all">Fetch веток</string>
+
+    <!-- Stash menu context menu -->
+    <string name="stash_context_menu_stash_with_message">Stash с сообщением</string>
+
+    <!-- Stashes context menu -->
+    <string name="stashes_context_menu_apply_stash">Применить stash</string>
+    <string name="stashes_context_menu_pop_stash">Pop stash</string>
+    <string name="stashes_context_menu_drop_stash">Удалить stash</string>
+
+    <!-- Status dir entries context menu -->
+    <string name="status_dir_entries_context_menu_unstage_changes">Unstage изменений в каталоге</string>
+    <string name="status_dir_entries_context_menu_stage_changes">Stage изменений в каталоге</string>
+    <string name="status_dir_entries_context_menu_discard_changes">Отменить изменения</string>
+
+    <!-- Submodules context menu -->
+    <string name="submodules_context_menu_initialize_submodule">Инициализировать подмодуль</string>
+    <string name="submodules_context_menu_open_submodule_in_tab">Открыть подмодуль в новой вкладке</string>
+    <string name="submodules_context_menu_sync_submodule">Синхронизировать подмодуль</string>
+    <string name="submodules_context_menu_update_submodule">Обновить подмодуль</string>
+    <string name="submodules_context_menu_delete_submodule">Удалить подмодуль</string>
+
+    <!-- Tag context menu -->
+    <string name="tag_context_menu_checkout_tag_commit">Checkout коммита тега</string>
+    <string name="tag_context_menu_delete_tag">Удалить тег</string>
+
+    <!-- Settings -->
+    <string name="settings_environment_default_clone_directory_title">Каталог клонирования по умолчанию</string>
+    <string name="settings_environment_default_clone_directory_description">Каталог, который будет предложен по умолчанию при клонировании репозитория</string>
+    <string name="settings_section_user_interface">Интерфейс</string>
+    <string name="settings_entry_appearance">Оформление</string>
+    <string name="settings_language_title">Язык</string>
+    <string name="settings_language_description">Язык интерфейса. «Системный» следует локали ОС.</string>
+    <string name="settings_theme_title">Тема</string>
+    <string name="settings_theme_description">Выбор светлой или тёмной темы интерфейса</string>
+    <string name="settings_entry_layout">Макет</string>
+    <string name="settings_entry_datetime">Дата и время</string>
+    <string name="settings_section_git">GIT</string>
+    <string name="settings_entry_environment">Окружение</string>
+    <string name="settings_entry_branches">Ветки</string>
+    <string name="settings_entry_remote_actions">Удалённые действия</string>
+    <string name="settings_section_network">Сеть</string>
+    <string name="settings_entry_proxy">Прокси</string>
+    <string name="settings_entry_auth">Аутентификация</string>
+    <string name="settings_entry_security">Безопасность</string>
+    <string name="settings_section_tools">Инструменты</string>
+    <string name="settings_entry_terminal">Терминал</string>
+    <string name="settings_entry_logs">Журналы</string>
+
+    <!-- Notifications -->
+    <string name="settings_lists_spacing_title">Интервал списков (Beta)</string>
+    <string name="settings_lists_spacing_description">Отступы вокруг элементов списков</string>
+    <string name="settings_scale_title">Масштаб</string>
+    <string name="settings_scale_description">Подстройте размер интерфейса под нужный масштаб</string>
+    <string name="settings_avatar_provider_title">Провайдер аватаров</string>
+    <string name="settings_avatar_provider_description">При использовании провайдера адреса e-mail хешируются с помощью SHA256</string>
+    <string name="settings_avatar_provider_none">Нет</string>
+    <string name="settings_avatar_provider_gravatar">Gravatar</string>
+    <string name="settings_lists_spacing_spaced">Просторный</string>
+    <string name="settings_lists_spacing_compact">Компактный</string>
+    <string name="settings_swap_staged_unstaged_title">Поменять местами staged/unstaged</string>
+    <string name="settings_swap_staged_unstaged_description">Показывать список unstaged-изменений над списком staged</string>
+    <string name="settings_datetime_use_system_title">Системный формат даты и времени</string>
+    <string name="settings_datetime_use_system_description">Если включено, дата отображается как «%1$s»</string>
+    <string name="settings_datetime_custom_format_title">Свой формат даты</string>
+    <string name="settings_datetime_use_24h_title">24-часовой формат времени</string>
+    <string name="settings_datetime_relative_title">Относительная дата</string>
+    <string name="settings_datetime_relative_description">Использовать «Сегодня» и «Вчера» вместо даты</string>
+    <string name="settings_fast_forward_merge_title">Fast-forward merge</string>
+    <string name="settings_fast_forward_merge_description">По возможности выполнять слияние fast-forward</string>
+    <string name="settings_auto_stash_on_merge_title">Автоматически stash перед merge</string>
+    <string name="settings_auto_stash_on_merge_description">Чтобы не потерять незакоммиченные изменения при отмене merge, приложение может сохранить их снимок</string>
+    <string name="settings_pull_with_rebase_title">Pull с rebase по умолчанию</string>
+    <string name="settings_pull_with_rebase_description">При pull делать rebase вместо merge</string>
+    <string name="settings_force_push_with_lease_title">Force push with lease</string>
+    <string name="settings_force_push_with_lease_description">Проверять актуальность локальной копии удалённой ветки, чтобы случайно не перезаписать чужие коммиты</string>
+    <string name="settings_use_proxy_title">Использовать прокси</string>
+    <string name="settings_use_proxy_description">Настройте прокси при необходимости</string>
+    <string name="settings_proxy_type_title">Тип прокси</string>
+    <string name="settings_proxy_type_description">HTTP или SOCKS</string>
+    <string name="settings_proxy_host_title">Имя хоста</string>
+    <string name="settings_proxy_port_title">Номер порта</string>
+    <string name="settings_proxy_auth_title">Аутентификация прокси</string>
+    <string name="settings_proxy_auth_description">Учётные данные для авторизации на прокси-сервере</string>
+    <string name="settings_proxy_login_title">Логин</string>
+    <string name="settings_proxy_password_title">Пароль</string>
+    <string name="settings_cache_credentials_title">Кэшировать HTTP-учётные данные в памяти</string>
+    <string name="settings_cache_credentials_description">Если включено, HTTP-учётные данные сохраняются до закрытия Gitnuro</string>
+    <string name="settings_do_not_verify_ssl_title">Не проверять SSL</string>
+    <string name="settings_do_not_verify_ssl_description">Если включено, допускается незащищённое HTTPS-соединение с удалённым сервером</string>
+    <string name="settings_terminal_path_title">Путь к терминалу</string>
+    <string name="settings_terminal_path_description">Если пусто, Gitnuro попытается открыть терминал по умолчанию</string>
+    <string name="settings_logs_title">Журналы</string>
+    <string name="settings_logs_description">Открыть папку с логами</string>
+    <string name="settings_logs_open_folder">Открыть папку</string>
+    <string name="notification_copied_branch_to_clipboard">«%1$s» скопировано в буфер</string>
+
+    <!-- Error dialog -->
+    <string name="error_dialog_copy_button_tooltip">Копировать ошибку</string>
+
+    <!-- Clone -->
+    <string name="clone_error_invalid_directory">Некорректный пустой каталог</string>
+    <string name="clone_error_invalid_url">Некорректный пустой URL</string>
+    <string name="clone_error_invalid_folder_name">Некорректное пустое имя папки</string>
+
+    <!-- Errors -->
+    <string name="error_create_branch_already_exists">Ветка «%1$s» уже существует, попробуйте другое имя</string>
+    <string name="error_create_branch_name_not_allowed">Имя ветки «%1$s» недопустимо, используйте только буквы и цифры.</string>
+    <string name="error_hook_rejection">Коммит отклонён hook: «%1$s»</string>
+    <string name="error_repository_path_not_set">Путь к репозиторию не сохранён. Если это ошибка, сообщите в issue tracker Gitnuro.</string>
+    <string name="error_repository_read_error">Не удалось прочитать репозиторий: %1$s. Проверьте, что он существует и доступен.</string>
+    <string name="error_stash_no_data">Нет данных для stash</string>
+    <string name="error_open_repository_dir_not_found">Не удалось открыть репозиторий: проверьте, что он существует и доступен</string>
+    <string name="error_open_repository_path_is_not_dir">Не удалось открыть репозиторий: указанный путь не является каталогом</string>
+    <string name="error_open_repository_repository_load">Не удалось открыть репозиторий: ошибка загрузки: %1$s</string>
+    <string name="error_open_repository_repo_not_found">Не удалось открыть репозиторий: в указанном пути репозиторий не найден</string>
+</resources>

--- a/app/src/main/composeResources/values/strings.xml
+++ b/app/src/main/composeResources/values/strings.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Gitnuro</string>
 
@@ -175,6 +176,10 @@
     <string name="settings_environment_default_clone_directory_description">Directory that will be used as default when cloning a repository</string>
     <string name="settings_section_user_interface">User interface</string>
     <string name="settings_entry_appearance">Appearance</string>
+    <string name="settings_language_title">Language</string>
+    <string name="settings_language_description">Interface language. System default follows the OS locale.</string>
+    <string name="settings_theme_title">Theme</string>
+    <string name="settings_theme_description">Select the UI theme between light and dark mode</string>
     <string name="settings_entry_layout">Layout</string>
     <string name="settings_entry_datetime">Date/Time</string>
     <string name="settings_section_git">GIT</string>
@@ -190,6 +195,51 @@
     <string name="settings_entry_logs">Logs</string>
 
     <!-- Notifications -->
+    <string name="settings_lists_spacing_title">Lists spacing (Beta)</string>
+    <string name="settings_lists_spacing_description">Spacing around lists items</string>
+    <string name="settings_scale_title">Scale</string>
+    <string name="settings_scale_description">Adapt the size the UI to your preferred scale</string>
+    <string name="settings_avatar_provider_title">Avatar provider</string>
+    <string name="settings_avatar_provider_description">When using a provider, the e-mail addresses will be hashed using SHA256</string>
+    <string name="settings_avatar_provider_none">None</string>
+    <string name="settings_avatar_provider_gravatar">Gravatar</string>
+    <string name="settings_lists_spacing_spaced">Spaced</string>
+    <string name="settings_lists_spacing_compact">Compact</string>
+    <string name="settings_swap_staged_unstaged_title">Swap position for staged/unstaged views</string>
+    <string name="settings_swap_staged_unstaged_description">Show the list of unstaged changes above the list of staged changes</string>
+    <string name="settings_datetime_use_system_title">Use system's Date/Time format</string>
+    <string name="settings_datetime_use_system_description">If enabled, current date would be shown as "%1$s"</string>
+    <string name="settings_datetime_custom_format_title">Custom date format</string>
+    <string name="settings_datetime_use_24h_title">Use 24h time</string>
+    <string name="settings_datetime_relative_title">Relative date</string>
+    <string name="settings_datetime_relative_description">Use "Today" and "Yesterday" instead of the date</string>
+    <string name="settings_fast_forward_merge_title">Fast-forward merge</string>
+    <string name="settings_fast_forward_merge_description">Try to fast-forward merges when possible</string>
+    <string name="settings_auto_stash_on_merge_title">Automatically stash uncommitted changes before merge</string>
+    <string name="settings_auto_stash_on_merge_description">To avoid losing work if the merge is aborted, the app can create a snapshot of the uncommitted changes</string>
+    <string name="settings_pull_with_rebase_title">Pull with rebase as default</string>
+    <string name="settings_pull_with_rebase_description">Rebase changes instead of merging when pulling</string>
+    <string name="settings_force_push_with_lease_title">Force push with lease</string>
+    <string name="settings_force_push_with_lease_description">Check if the local version remote branch is up to date to avoid accidentally overriding unintended commits</string>
+    <string name="settings_use_proxy_title">Use proxy</string>
+    <string name="settings_use_proxy_description">Set up your proxy configuration if needed</string>
+    <string name="settings_proxy_type_title">Proxy type</string>
+    <string name="settings_proxy_type_description">Pick between HTTP or SOCKS</string>
+    <string name="settings_proxy_host_title">Host name</string>
+    <string name="settings_proxy_port_title">Port number</string>
+    <string name="settings_proxy_auth_title">Proxy authentication</string>
+    <string name="settings_proxy_auth_description">Use your credentials to provide your identity the proxy server</string>
+    <string name="settings_proxy_login_title">Login</string>
+    <string name="settings_proxy_password_title">Password</string>
+    <string name="settings_cache_credentials_title">Cache HTTP credentials in memory</string>
+    <string name="settings_cache_credentials_description">If active, HTTP Credentials will be remembered until Gitnuro is closed</string>
+    <string name="settings_do_not_verify_ssl_title">Do not verify SSL security</string>
+    <string name="settings_do_not_verify_ssl_description">If active, you may connect to the remote server via insecure HTTPS connection</string>
+    <string name="settings_terminal_path_title">Custom terminal path</string>
+    <string name="settings_terminal_path_description">If empty, Gitnuro will try to open the default terminal emulator</string>
+    <string name="settings_logs_title">Logs</string>
+    <string name="settings_logs_description">Open the logs folder</string>
+    <string name="settings_logs_open_folder">Open folder</string>
     <string name="notification_copied_branch_to_clipboard">"%1$s" copied to clipboard</string>
 
     <!-- Error dialog -->
@@ -207,6 +257,7 @@
     <string name="error_hook_rejection">Commit rejected by hook: "%1$s"</string>
 
     <string name="error_repository_path_not_set">Repository path is not stored, if you believe this is a bug, please report it to Gitnuro's issue tracker.</string>
+
     <string name="error_repository_read_error">Failed to read a repository: %1$s. Please verify the repository exists and it's accessible.</string>
 
     <string name="error_stash_no_data">No data to stash</string>
@@ -215,6 +266,4 @@
     <string name="error_open_repository_path_is_not_dir">Failed to open repository, specified path is not a directory</string>
     <string name="error_open_repository_repository_load">Failed to open repository, could not load repository: %1$s</string>
     <string name="error_open_repository_repo_not_found">Failed to open repository, could not find a repository in the specified path</string>
-
-
 </resources>

--- a/app/src/main/kotlin/com/jetpackduba/gitnuro/App.kt
+++ b/app/src/main/kotlin/com/jetpackduba/gitnuro/App.kt
@@ -44,6 +44,7 @@ import com.jetpackduba.gitnuro.domain.AppStateManager
 import com.jetpackduba.gitnuro.theme.AppTheme
 import com.jetpackduba.gitnuro.theme.ColorsScheme
 import com.jetpackduba.gitnuro.theme.onBackgroundSecondary
+import com.jetpackduba.gitnuro.locale.applyAppLanguage
 import com.jetpackduba.gitnuro.ui.AppTab
 import com.jetpackduba.gitnuro.ui.AppViewModel
 import com.jetpackduba.gitnuro.ui.components.TabsRow
@@ -127,6 +128,7 @@ class App @Inject constructor(
             addDirTab(dirToOpen)
 
         val themeInitial = appSettings.theme.first()
+        val languageInitial = appSettings.language.first()
         val customThemeInitial = appSettings.customTheme.firstOrNull()
         val scaleInitial = appSettings.scaleUi.firstOrNull()
         val linesHeightTypeInitial = appSettings.linesHeightType.first()
@@ -138,6 +140,8 @@ class App @Inject constructor(
 
         application {
             val theme by appSettings.theme.collectAsState(themeInitial)
+            val language by appSettings.language.collectAsState(languageInitial)
+            LaunchedEffect(language) { applyAppLanguage(language) }
             val customThemeRaw by appSettings.customTheme.collectAsState(customThemeInitial)
             val customTheme = remember(customThemeRaw) {
                 val customThemeRaw = customThemeRaw
@@ -216,13 +220,16 @@ class App @Inject constructor(
                 CompositionLocalProvider(
                     values = compositionValues.toTypedArray()
                 ) {
-                    AppTheme(
-                        selectedTheme = theme,
-                        customTheme = customTheme,
-                        linesHeightType = linesHeightType,
-                    ) {
-                        Box(modifier = Modifier.background(MaterialTheme.colors.background)) {
-                            AppTabs()
+                    // Recompose when language changes so stringResource() reloads catalogs.
+                    key(language) {
+                        AppTheme(
+                            selectedTheme = theme,
+                            customTheme = customTheme,
+                            linesHeightType = linesHeightType,
+                        ) {
+                            Box(modifier = Modifier.background(MaterialTheme.colors.background)) {
+                                AppTabs()
+                            }
                         }
                     }
                 }

--- a/app/src/main/kotlin/com/jetpackduba/gitnuro/locale/AppLocale.kt
+++ b/app/src/main/kotlin/com/jetpackduba/gitnuro/locale/AppLocale.kt
@@ -1,0 +1,23 @@
+package com.jetpackduba.gitnuro.locale
+
+import com.jetpackduba.gitnuro.domain.models.ui.AppLanguage
+import java.util.Locale
+
+/**
+ * Captures the process-start JVM locale so [AppLanguage.System] can restore it
+ * after the user previously selected a fixed language.
+ */
+private val systemLocale: Locale = Locale.getDefault()
+
+fun applyAppLanguage(language: AppLanguage) {
+    val locale = when (language) {
+        AppLanguage.System -> systemLocale
+        else -> Locale.forLanguageTag(language.code)
+    }
+    Locale.setDefault(locale)
+}
+
+fun currentAppLocale(language: AppLanguage): Locale = when (language) {
+    AppLanguage.System -> systemLocale
+    else -> Locale.forLanguageTag(language.code)
+}

--- a/app/src/main/kotlin/com/jetpackduba/gitnuro/ui/dialogs/settings/SettingsDialog.kt
+++ b/app/src/main/kotlin/com/jetpackduba/gitnuro/ui/dialogs/settings/SettingsDialog.kt
@@ -26,6 +26,7 @@ import com.jetpackduba.gitnuro.domain.models.Error
 import com.jetpackduba.gitnuro.domain.models.ProxyType
 import com.jetpackduba.gitnuro.domain.models.ui.LinesHeightType
 import com.jetpackduba.gitnuro.domain.models.ui.Theme
+import com.jetpackduba.gitnuro.domain.models.ui.AppLanguage
 import com.jetpackduba.gitnuro.extensions.handMouseClickable
 import com.jetpackduba.gitnuro.extensions.toSmartSystemString
 import com.jetpackduba.gitnuro.theme.backgroundSelected
@@ -137,6 +138,10 @@ val linesHeightTypesList = listOf(
     DropDownOption(LinesHeightType.COMPACT, "Compact"),
 )
 
+val languageOptionsList = AppLanguage.entries.map { language ->
+    DropDownOption(language, language.displayName)
+}
+
 @Composable
 fun SettingsDialog(
     settingsViewModel: SettingsViewModel,
@@ -241,8 +246,8 @@ fun Proxy(settingsViewState: SettingsViewState, onAction: (SettingsAction) -> Un
 
     Column {
         SettingToggle(
-            title = "Use proxy",
-            subtitle = "Set up your proxy configuration if needed",
+            title = stringResource(Res.string.settings_use_proxy_title),
+            subtitle = stringResource(Res.string.settings_use_proxy_description),
             value = useProxy,
             onValueChanged = {
                 onAction(SettingsAction.SetConfig(AppConfig.UseProxy(it)))
@@ -250,8 +255,8 @@ fun Proxy(settingsViewState: SettingsViewState, onAction: (SettingsAction) -> Un
         )
 
         SettingDropDown(
-            title = "Proxy type",
-            subtitle = "Pick between HTTP or SOCKS",
+            title = stringResource(Res.string.settings_proxy_type_title),
+            subtitle = stringResource(Res.string.settings_proxy_type_description),
             dropDownOptions = proxyTypesDropDownOptions,
             currentOption = settingsViewState.proxyType,
             onOptionSelected = {
@@ -260,7 +265,7 @@ fun Proxy(settingsViewState: SettingsViewState, onAction: (SettingsAction) -> Un
         )
 
         SettingTextInput(
-            title = "Host name",
+            title = stringResource(Res.string.settings_proxy_host_title),
             subtitle = "",
             value = settingsViewState.proxyHostName.orEmpty(),
             enabled = useProxy,
@@ -270,7 +275,7 @@ fun Proxy(settingsViewState: SettingsViewState, onAction: (SettingsAction) -> Un
         )
 
         SettingIntInput(
-            title = "Port number",
+            title = stringResource(Res.string.settings_proxy_port_title),
             subtitle = "",
             value = settingsViewState.proxyPortNumber ?: 0,
             onValueChanged = {
@@ -280,8 +285,8 @@ fun Proxy(settingsViewState: SettingsViewState, onAction: (SettingsAction) -> Un
         )
 
         SettingToggle(
-            title = "Proxy authentication",
-            subtitle = "Use your credentials to provide your identity the proxy server",
+            title = stringResource(Res.string.settings_proxy_auth_title),
+            subtitle = stringResource(Res.string.settings_proxy_auth_description),
             value = proxyUseAuth,
             onValueChanged = {
                 onAction(SettingsAction.SetConfig(AppConfig.ProxyUseAuth(it)))
@@ -289,7 +294,7 @@ fun Proxy(settingsViewState: SettingsViewState, onAction: (SettingsAction) -> Un
         )
 
         SettingTextInput(
-            title = "Login",
+            title = stringResource(Res.string.settings_proxy_login_title),
             subtitle = "",
             value = settingsViewState.proxyHostUser.orEmpty(),
             enabled = useProxy && proxyUseAuth,
@@ -300,7 +305,7 @@ fun Proxy(settingsViewState: SettingsViewState, onAction: (SettingsAction) -> Un
 
 
         SettingTextInput(
-            title = "Password",
+            title = stringResource(Res.string.settings_proxy_password_title),
             subtitle = "",
             value = settingsViewState.proxyHostPassword.orEmpty(),
             enabled = useProxy && proxyUseAuth,
@@ -361,8 +366,8 @@ private fun RemoteActions(settingsViewState: SettingsViewState, onAction: (Setti
     val pushWithLease = settingsViewState.pushWithLease
 
     SettingToggle(
-        title = "Pull with rebase as default",
-        subtitle = "Rebase changes instead of merging when pulling",
+        title = stringResource(Res.string.settings_pull_with_rebase_title),
+        subtitle = stringResource(Res.string.settings_pull_with_rebase_description),
         value = pullRebase,
         onValueChanged = { value ->
             onAction(SettingsAction.SetConfig(AppConfig.PullWithRebase(value)))
@@ -370,8 +375,8 @@ private fun RemoteActions(settingsViewState: SettingsViewState, onAction: (Setti
     )
 
     SettingToggle(
-        title = "Force push with lease",
-        subtitle = "Check if the local version remote branch is up to date to avoid accidentally overriding unintended commits",
+        title = stringResource(Res.string.settings_force_push_with_lease_title),
+        subtitle = stringResource(Res.string.settings_force_push_with_lease_description),
         value = pushWithLease,
         onValueChanged = { value ->
             onAction(SettingsAction.SetConfig(AppConfig.PushWithLease(value)))
@@ -385,8 +390,8 @@ private fun Authentication(settingsViewState: SettingsViewState, onAction: (Sett
     val cacheCredentialsInMemory = settingsViewState.cacheCredentialsInMemory
 
     SettingToggle(
-        title = "Cache HTTP credentials in memory",
-        subtitle = "If active, HTTP Credentials will be remembered until Gitnuro is closed",
+        title = stringResource(Res.string.settings_cache_credentials_title),
+        subtitle = stringResource(Res.string.settings_cache_credentials_description),
         value = cacheCredentialsInMemory,
         onValueChanged = { value ->
             onAction(SettingsAction.SetConfig(AppConfig.CacheCredentialsInMemory(value)))
@@ -399,8 +404,8 @@ private fun Security(settingsViewState: SettingsViewState, onAction: (SettingsAc
     val verifySsl = settingsViewState.verifySsl
 
     SettingToggle(
-        title = "Do not verify SSL security",
-        subtitle = "If active, you may connect to the remote server via insecure HTTPS connection",
+        title = stringResource(Res.string.settings_do_not_verify_ssl_title),
+        subtitle = stringResource(Res.string.settings_do_not_verify_ssl_description),
         value = !verifySsl,
         onValueChanged = { value ->
             onAction(SettingsAction.SetConfig(AppConfig.CacheCredentialsInMemory(!value)))
@@ -413,8 +418,8 @@ fun Terminal(settingsViewState: SettingsViewState, onAction: (SettingsAction) ->
     val terminalPath = settingsViewState.terminalPath.orEmpty()
 
     SettingTextInput(
-        title = "Custom terminal path",
-        subtitle = "If empty, Gitnuro will try to open the default terminal emulator",
+        title = stringResource(Res.string.settings_terminal_path_title),
+        subtitle = stringResource(Res.string.settings_terminal_path_description),
         value = terminalPath,
         onValueChanged = { value ->
             onAction(SettingsAction.SetConfig(AppConfig.TerminalPath(value)))
@@ -425,9 +430,9 @@ fun Terminal(settingsViewState: SettingsViewState, onAction: (SettingsAction) ->
 @Composable
 fun Logs(settingsViewState: SettingsViewState, onAction: (SettingsAction) -> Unit) {
     SettingButton(
-        title = "Logs",
-        subtitle = "Open the logs folder",
-        buttonText = "Open folder",
+        title = stringResource(Res.string.settings_logs_title),
+        subtitle = stringResource(Res.string.settings_logs_description),
+        buttonText = stringResource(Res.string.settings_logs_open_folder),
         onClick = {
             onAction(SettingsAction.OpenLogsFolder)
         }
@@ -457,8 +462,8 @@ private fun Branches(settingsViewState: SettingsViewState, onAction: (SettingsAc
     val mergeAutoStash = settingsViewState.autoStashOnMerge
 
     SettingToggle(
-        title = "Fast-forward merge",
-        subtitle = "Try to fast-forward merges when possible",
+        title = stringResource(Res.string.settings_fast_forward_merge_title),
+        subtitle = stringResource(Res.string.settings_fast_forward_merge_description),
         value = fastForwardMerge,
         onValueChanged = { value ->
             onAction(SettingsAction.SetConfig(AppConfig.FastForwardMerge(value)))
@@ -466,8 +471,8 @@ private fun Branches(settingsViewState: SettingsViewState, onAction: (SettingsAc
     )
 
     SettingToggle(
-        title = "Automatically stash uncommitted changes before merge",
-        subtitle = "To avoid losing work if the merge is aborted, the app can create a snapshot of the uncommitted changes",
+        title = stringResource(Res.string.settings_auto_stash_on_merge_title),
+        subtitle = stringResource(Res.string.settings_auto_stash_on_merge_description),
         value = mergeAutoStash,
         onValueChanged = { value ->
             onAction(SettingsAction.SetConfig(AppConfig.AutoStashOnMerge(value)))
@@ -480,8 +485,8 @@ private fun Layout(settingsViewState: SettingsViewState, onAction: (SettingsActi
     val swapUncommittedChanges = settingsViewState.swapStatusPanes
 
     SettingToggle(
-        title = "Swap position for staged/unstaged views",
-        subtitle = "Show the list of unstaged changes above the list of staged changes",
+        title = stringResource(Res.string.settings_swap_staged_unstaged_title),
+        subtitle = stringResource(Res.string.settings_swap_staged_unstaged_description),
         value = swapUncommittedChanges,
         onValueChanged = { value ->
             onAction(SettingsAction.SetConfig(AppConfig.SwapStatusPanes(value)))
@@ -507,8 +512,8 @@ private fun DateTime(settingsViewState: SettingsViewState, onAction: (SettingsAc
         currentInstant.toSmartSystemString(allowRelative = false, useSystemDefaultFormat = true)
 
     SettingToggle(
-        title = "Use system's Date/Time format",
-        subtitle = "If enabled, current date would be shown as \"$currentDateSystemDefault\"",
+        title = stringResource(Res.string.settings_datetime_use_system_title),
+        subtitle = stringResource(Res.string.settings_datetime_use_system_description, currentDateSystemDefault),
         value = useDefault,
         onValueChanged = { value ->
             onAction(SettingsAction.SetConfig(AppConfig.DateFormatUseDefault(value)))
@@ -523,7 +528,7 @@ private fun DateTime(settingsViewState: SettingsViewState, onAction: (SettingsAc
     }
 
     SettingTextInput(
-        title = "Custom date format",
+        title = stringResource(Res.string.settings_datetime_custom_format_title),
         subtitle = customFormatSubtitle,
         value = customFormat,
         isError = isError,
@@ -546,7 +551,7 @@ private fun DateTime(settingsViewState: SettingsViewState, onAction: (SettingsAc
     }
 
     SettingToggle(
-        title = "Use 24h time",
+        title = stringResource(Res.string.settings_datetime_use_24h_title),
         subtitle = is24hSubtitle,
         enabled = !useDefault,
         value = is24h,
@@ -556,8 +561,8 @@ private fun DateTime(settingsViewState: SettingsViewState, onAction: (SettingsAc
     )
 
     SettingToggle(
-        title = "Relative date",
-        subtitle = "Use \"Today\" and \"Yesterday\" instead of the date",
+        title = stringResource(Res.string.settings_datetime_relative_title),
+        subtitle = stringResource(Res.string.settings_datetime_relative_description),
         value = useRelative,
         onValueChanged = { value ->
             onAction(SettingsAction.SetConfig(AppConfig.DateFormatUseRelative(value)))
@@ -568,14 +573,25 @@ private fun DateTime(settingsViewState: SettingsViewState, onAction: (SettingsAc
 @Composable
 private fun Appearance(settingsViewState: SettingsViewState, onAction: (SettingsAction) -> Unit) {
     val currentTheme = settingsViewState.theme
+    val currentLanguage = settingsViewState.language
     val customTheme = settingsViewState.customTheme
     val currentLinesHeightType = settingsViewState.linesHeightType
     val avatarProvider = settingsViewState.avatarProvider
     val (errorToDisplay, setErrorToDisplay) = remember { mutableStateOf<Error?>(null) }
 
     SettingDropDown(
-        title = "Theme",
-        subtitle = "Select the UI theme between light and dark mode",
+        title = stringResource(Res.string.settings_language_title),
+        subtitle = stringResource(Res.string.settings_language_description),
+        dropDownOptions = languageOptionsList,
+        currentOption = currentLanguage,
+        onOptionSelected = { option ->
+            onAction(SettingsAction.SetConfig(AppConfig.Language(option.value)))
+        }
+    )
+
+    SettingDropDown(
+        title = stringResource(Res.string.settings_theme_title),
+        subtitle = stringResource(Res.string.settings_theme_description),
         dropDownOptions = themeLists,
         currentOption = currentTheme,
         onOptionSelected = { themeDropDown ->
@@ -609,9 +625,12 @@ private fun Appearance(settingsViewState: SettingsViewState, onAction: (Settings
     }
 
     SettingDropDown(
-        title = "Lists spacing (Beta)",
-        subtitle = "Spacing around lists items",
-        dropDownOptions = linesHeightTypesList,
+        title = stringResource(Res.string.settings_lists_spacing_title),
+        subtitle = stringResource(Res.string.settings_lists_spacing_description),
+        dropDownOptions = listOf(
+            DropDownOption(LinesHeightType.SPACED, stringResource(Res.string.settings_lists_spacing_spaced)),
+            DropDownOption(LinesHeightType.COMPACT, stringResource(Res.string.settings_lists_spacing_compact)),
+        ),
         currentOption = currentLinesHeightType,
         onOptionSelected = { dropDown ->
             onAction(SettingsAction.SetConfig(AppConfig.LinesHeight(dropDown.value)))
@@ -654,8 +673,8 @@ private fun Appearance(settingsViewState: SettingsViewState, onAction: (Settings
     }
 
     SettingDropDown(
-        title = "Scale",
-        subtitle = "Adapt the size the UI to your preferred scale",
+        title = stringResource(Res.string.settings_scale_title),
+        subtitle = stringResource(Res.string.settings_scale_description),
         dropDownOptions = options,
         currentOption = scaleValue.value,
         onOptionSelected = { newValue ->
@@ -664,12 +683,12 @@ private fun Appearance(settingsViewState: SettingsViewState, onAction: (Settings
     )
 
     SettingDropDown(
-        title = "Avatar provider",
-        subtitle = "When using a provider, the e-mail addresses will be hashed using SHA256",
+        title = stringResource(Res.string.settings_avatar_provider_title),
+        subtitle = stringResource(Res.string.settings_avatar_provider_description),
         currentOption = avatarProvider,
         dropDownOptions = listOf(
-            DropDownOption(AvatarProviderType.None, "None"),
-            DropDownOption(AvatarProviderType.Gravatar, "Gravatar"),
+            DropDownOption(AvatarProviderType.None, stringResource(Res.string.settings_avatar_provider_none)),
+            DropDownOption(AvatarProviderType.Gravatar, stringResource(Res.string.settings_avatar_provider_gravatar)),
         ),
         onOptionSelected = {
             onAction(SettingsAction.SetConfig(AppConfig.AvatarProvider(it.value)))

--- a/app/src/main/kotlin/com/jetpackduba/gitnuro/viewmodels/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/jetpackduba/gitnuro/viewmodels/SettingsViewModel.kt
@@ -10,6 +10,7 @@ import com.jetpackduba.gitnuro.domain.models.AvatarProviderType
 import com.jetpackduba.gitnuro.domain.models.ProxyType
 import com.jetpackduba.gitnuro.domain.models.ui.LinesHeightType
 import com.jetpackduba.gitnuro.domain.models.ui.Theme
+import com.jetpackduba.gitnuro.domain.models.ui.AppLanguage
 import com.jetpackduba.gitnuro.domain.services.AppSettingsService
 import com.jetpackduba.gitnuro.extensions.stateIn
 import com.jetpackduba.gitnuro.system.OpenUrlInBrowserUseCase
@@ -50,6 +51,7 @@ class SettingsViewModel @Inject constructor(
         return combine(
             appSettingsService.scaleUi,
             appSettingsService.theme,
+            appSettingsService.language,
             appSettingsService.customTheme,
             appSettingsService.linesHeightType,
             appSettingsService.dateFormatUseDefault,
@@ -75,6 +77,7 @@ class SettingsViewModel @Inject constructor(
             appSettingsService.terminalPath,
         ) { scaleUi,
             theme,
+            language,
             customTheme,
             linesHeightType,
             dateFormatUseDefault,
@@ -101,6 +104,7 @@ class SettingsViewModel @Inject constructor(
 
             SettingsViewState(
                 scaleUi,
+                language,
                 theme,
                 customTheme,
                 linesHeightType,
@@ -132,6 +136,7 @@ class SettingsViewModel @Inject constructor(
     private fun emptySettingsState(): SettingsViewState {
         return SettingsViewState(
             scaleUi = null,
+            language = AppLanguage.System,
             theme = Theme.Light,
             customTheme = "",
             linesHeightType = LinesHeightType.SPACED,
@@ -163,6 +168,7 @@ class SettingsViewModel @Inject constructor(
 @Immutable
 data class SettingsViewState(
     val scaleUi: Float?,
+    val language: AppLanguage,
     val theme: Theme,
     val customTheme: String?,
     val linesHeightType: LinesHeightType,

--- a/data/src/main/kotlin/com/jetpackduba/gitnuro/data/repositories/configuration/DataStoreAppSettingsRepository.kt
+++ b/data/src/main/kotlin/com/jetpackduba/gitnuro/data/repositories/configuration/DataStoreAppSettingsRepository.kt
@@ -13,6 +13,7 @@ import com.jetpackduba.gitnuro.data.repositories.configuration.mappers.ThemeMapp
 import com.jetpackduba.gitnuro.domain.models.AppConfig
 import com.jetpackduba.gitnuro.domain.models.ProxyType
 import com.jetpackduba.gitnuro.domain.models.ui.AppWindowPlacement
+import com.jetpackduba.gitnuro.domain.models.ui.AppLanguage
 import com.jetpackduba.gitnuro.domain.repositories.AppSettingsRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -32,6 +33,7 @@ private const val DEFAULT_THIRD_PANE_WIDTH = 330f
 
 private val scaleUiPreference get() = floatPreferencesKey("scale_ui")
 private val themePreference get() = stringPreferencesKey("theme")
+private val languagePreference get() = stringPreferencesKey("language")
 private val customThemePreference get() = stringPreferencesKey("custom_theme")
 private val linesHeightPreference get() = stringPreferencesKey("lines_height")
 private val swapStatusPanesPreference get() = booleanPreferencesKey("swap_status_panes")
@@ -93,6 +95,8 @@ class DataStoreAppSettingsRepository @Inject constructor(
     override val scaleUi = preferences.data[scaleUiPreference]
 
     override val theme = preferences.data[themePreference].map { themeMapper.toDomain(it) }
+    override val language =
+        preferences.data[languagePreference].map { AppLanguage.fromCode(it) }
     override val customTheme = preferences.data[customThemePreference]
 
     override val linesHeightType =
@@ -160,6 +164,7 @@ class DataStoreAppSettingsRepository @Inject constructor(
                 )
 
                 is AppConfig.Theme -> setValue(themePreference, themeMapper.toData(appConfig.value))
+                is AppConfig.Language -> setValue(languagePreference, appConfig.value.code)
                 is AppConfig.CustomTheme -> setValue(customThemePreference, appConfig.value)
                 is AppConfig.SwapStatusPanes -> setValue(swapStatusPanesPreference, appConfig.value)
                 is AppConfig.DiffDisplayFullFile -> setValue(diffDisplayFullFilePreference, appConfig.value)

--- a/domain/src/main/kotlin/com/jetpackduba/gitnuro/domain/models/AppConfig.kt
+++ b/domain/src/main/kotlin/com/jetpackduba/gitnuro/domain/models/AppConfig.kt
@@ -24,6 +24,7 @@ sealed interface AppConfig {
     data class CacheCredentialsInMemory(val value: Boolean) : AppConfig
     data class AvatarProvider(val value: AvatarProviderType) : AppConfig
     data class Theme(val value: com.jetpackduba.gitnuro.domain.models.ui.Theme) : AppConfig
+    data class Language(val value: com.jetpackduba.gitnuro.domain.models.ui.AppLanguage) : AppConfig
     data class CustomTheme(val value: String) : AppConfig
     data class SwapStatusPanes(val value: Boolean) : AppConfig
     data class DiffDisplayFullFile(val value: Boolean) : AppConfig

--- a/domain/src/main/kotlin/com/jetpackduba/gitnuro/domain/models/ui/AppLanguage.kt
+++ b/domain/src/main/kotlin/com/jetpackduba/gitnuro/domain/models/ui/AppLanguage.kt
@@ -1,0 +1,22 @@
+package com.jetpackduba.gitnuro.domain.models.ui
+
+/**
+ * UI language preference.
+ *
+ * [code] is persisted in DataStore. Use BCP-47 language tags for concrete
+ * locales (e.g. "en", "ru", "uk"). [System] follows the JVM default locale
+ * captured at process start.
+ */
+enum class AppLanguage(val code: String, val displayName: String) {
+    System("system", "System OS language"),
+    English("en", "English"),
+    Russian("ru", "Русский"),
+    ;
+
+    companion object {
+        fun fromCode(code: String?): AppLanguage {
+            if (code.isNullOrBlank()) return System
+            return entries.find { it.code.equals(code, ignoreCase = true) } ?: System
+        }
+    }
+}

--- a/domain/src/main/kotlin/com/jetpackduba/gitnuro/domain/repositories/AppSettingsRepository.kt
+++ b/domain/src/main/kotlin/com/jetpackduba/gitnuro/domain/repositories/AppSettingsRepository.kt
@@ -6,12 +6,14 @@ import com.jetpackduba.gitnuro.domain.models.DiffTextViewType
 import com.jetpackduba.gitnuro.domain.models.ProxyType
 import com.jetpackduba.gitnuro.domain.models.ui.LinesHeightType
 import com.jetpackduba.gitnuro.domain.models.ui.Theme
+import com.jetpackduba.gitnuro.domain.models.ui.AppLanguage
 import kotlinx.coroutines.flow.Flow
 
 interface AppSettingsRepository {
     // UI
     val scaleUi: Flow<Float?>
     val theme: Flow<Theme?>
+    val language: Flow<AppLanguage?>
     val customTheme: Flow<String?>
     val linesHeightType: Flow<LinesHeightType?>
     val dateFormatUseDefault: Flow<Boolean?>

--- a/domain/src/main/kotlin/com/jetpackduba/gitnuro/domain/services/AppSettingsService.kt
+++ b/domain/src/main/kotlin/com/jetpackduba/gitnuro/domain/services/AppSettingsService.kt
@@ -7,6 +7,7 @@ import com.jetpackduba.gitnuro.domain.models.DiffTextViewType
 import com.jetpackduba.gitnuro.domain.models.ProxyType
 import com.jetpackduba.gitnuro.domain.models.ui.LinesHeightType
 import com.jetpackduba.gitnuro.domain.models.ui.Theme
+import com.jetpackduba.gitnuro.domain.models.ui.AppLanguage
 import com.jetpackduba.gitnuro.domain.repositories.AppSettingsRepository
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
@@ -20,6 +21,8 @@ class AppSettingsService @Inject constructor(
 
     val scaleUi: Flow<Float?> get() = appSettingsRepository.scaleUi
     val theme: Flow<Theme> get() = appSettingsRepository.theme.defaultIfNull { DEFAULT_THEME }
+    val language: Flow<AppLanguage>
+        get() = appSettingsRepository.language.defaultIfNull { DEFAULT_LANGUAGE }
     val customTheme: Flow<String?> get() = appSettingsRepository.customTheme
     val linesHeightType: Flow<LinesHeightType> get() = appSettingsRepository.linesHeightType.defaultIfNull { DEFAULT_LINES_HEIGHT }
     val dateFormatUseDefault: Flow<Boolean> get() = appSettingsRepository.dateFormatUseDefault.defaultIfNull { DEFAULT_DATE_USE_DEFAULT }
@@ -49,6 +52,7 @@ class AppSettingsService @Inject constructor(
 
     companion object {
         val DEFAULT_THEME = Theme.Dark
+        val DEFAULT_LANGUAGE = AppLanguage.System
         val DEFAULT_LINES_HEIGHT = LinesHeightType.SPACED
         const val DEFAULT_DATE_USE_DEFAULT = true
         const val DEFAULT_DATE_IS_24H = true


### PR DESCRIPTION
## Summary

Adds optional UI language selection and a Russian translation catalog for Gitnuro.

Related to #225.

## Changes

### Language preference
- New `AppLanguage` model (`system`, `en`, `ru`, …) stored via DataStore
- `AppConfig.Language` wired through repository / service / settings state
- Language dropdown in **Settings → Appearance**
- Runtime application via `Locale.setDefault` + recomposition (`key(language)`) so `stringResource` picks the right catalog

### String resources
- Hardcoded Settings labels moved to `composeResources` (`stringResource`)
- Full `values-ru/strings.xml` with the **same key set** as `values/strings.xml` (menus, context menus, settings, errors, …)
- Includes language/theme setting strings and the Settings items previously left in English

## Notes

- Without a matching `values-xx/` entry, Compose falls back to `values/` (English).
- Dropdown display names for languages themselves remain in `AppLanguage.displayName` (not resource-backed).
- Further locales can reuse the same pattern: add `values-xx/strings.xml` with the full key set and an `AppLanguage` entry.